### PR TITLE
Revert "Feat vs anno labels"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
+__pycache__/
 .ipynb_checkpoints/
-
 # Python
 __pycache__/
 *.py[cod]

--- a/server/feat_vs_anno_server.py
+++ b/server/feat_vs_anno_server.py
@@ -6,18 +6,6 @@ import spac.visualization
 
 
 def feat_vs_anno_server(input, output, session, shared):
-    rendering_state = reactive.Value(False)
-
-    @reactive.effect
-    @reactive.event(input.go_hm1)
-    def handle_render_start():
-        rendering_state.set(True)
-
-    @reactive.effect
-    @reactive.event(input.cancel_hm1)
-    def handle_cancel_click():
-        rendering_state.set(False)
-
     def on_layer_check():
         return input.hm1_layer() if input.hm1_layer() != "Original" else None
 
@@ -30,8 +18,8 @@ def feat_vs_anno_server(input, output, session, shared):
             return (None, None) to indicate that no dendrogram is available.
         '''
         return (
-            (input.h2_anno_dendro(), input.h2_feat_dendro())
-            if input.dendogram()
+            (input.h2_anno_dendro(), input.h2_feat_dendro()) 
+            if input.dendogram() 
             else (None, None)
         )
 
@@ -40,78 +28,48 @@ def feat_vs_anno_server(input, output, session, shared):
     @reactive.event(input.go_hm1, ignore_none=True)
     def spac_Heatmap():
         adata = ad.AnnData(
-            X=shared['X_data'].get(),
-            obs=pd.DataFrame(shared['obs_data'].get()),
-            var=pd.DataFrame(shared['var_data'].get()),
-            layers=shared['layers_data'].get(),
+            X=shared['X_data'].get(), 
+            obs=pd.DataFrame(shared['obs_data'].get()), 
+            var=pd.DataFrame(shared['var_data'].get()), 
+            layers=shared['layers_data'].get(), 
             dtype=shared['X_data'].get().dtype
         )
-        if adata is None:
-            return None
+        if adata is not None:
+            vmin = input.min_select()
+            vmax = input.max_select()  
+            cmap = input.hm1_cmap()  # Get the selected color map from the dropdown 
+            kwargs = {"vmin": vmin,"vmax": vmax,} 
 
-        vmin = input.min_select()
-        vmax = input.max_select()
-        cmap = input.hm1_cmap()
-        fontsize = input.axis_label_fontsize()
-        kwargs = {"vmin": vmin, "vmax": vmax}
-        cluster_annotations, cluster_features = on_dendro_check()
-
-        try:
+            cluster_annotations, cluster_features = on_dendro_check()
             df, fig, ax = spac.visualization.hierarchical_heatmap(
-                adata,
-                annotation=input.hm1_anno(),
-                layer=on_layer_check(),
-                z_score=None,
+                adata, 
+                annotation=input.hm1_anno(), 
+                layer=on_layer_check(), 
+                z_score=None, 
                 cluster_annotations=cluster_annotations,
-                cluster_feature=cluster_features,
+                cluster_feature=cluster_features, 
                 **kwargs
             )
-        except Exception as e:
-            print("Heatmap generation failed:", e)
-            return None
 
-        if fig is None or not hasattr(fig, "ax_heatmap"):
-            print("Invalid figure structure.")
-            return None
+            # Only update if a non-default color map is selected
+            if cmap != "viridis":  
+                fig.ax_heatmap.collections[0].set_cmap(cmap)
 
-        if cmap != "viridis":
-            fig.ax_heatmap.collections[0].set_cmap(cmap)
+            shared['df_heatmap'].set(df)
+            
+            # Rotate x-axis labels
+            fig.ax_heatmap.set_xticklabels(
+                fig.ax_heatmap.get_xticklabels(),
+                rotation=input.hm_x_label_rotation(),  # degrees
+                horizontalalignment='right'
+            )
+            # fig is a seaborn.matrix.ClusterGrid
+            fig.fig.subplots_adjust(bottom=0.4)
+            fig.fig.subplots_adjust(left=0.1)
+            return fig
 
-        shared['df_heatmap'].set(df)
-
-        #Rotate X and Y axis labels
-        fig.ax_heatmap.set_xticklabels(
-            fig.ax_heatmap.get_xticklabels(),
-            rotation=input.hm_x_label_rotation(),
-            horizontalalignment='right'
-        )
-        fig.ax_heatmap.set_yticklabels(
-            fig.ax_heatmap.get_yticklabels(),
-            rotation=input.hm_y_label_rotation(),
-            verticalalignment='center'
-        )
-        
-        # Abbreviate labels if enabled
-        def abbreviate_labels(labels, limit):
-            return [label.get_text()[:limit] if label.get_text() else "" for label in labels]
-
-        if input.enable_abbreviation():
-            limit = input.label_char_limit()
-            abbreviated_xticks = abbreviate_labels(fig.ax_heatmap.get_xticklabels(), limit)
-            fig.ax_heatmap.set_xticklabels(abbreviated_xticks, rotation=input.hm_x_label_rotation())
-            abbreviated_yticks = abbreviate_labels(fig.ax_heatmap.get_yticklabels(), limit)
-            fig.ax_heatmap.set_yticklabels(abbreviated_yticks, rotation=input.hm_y_label_rotation())
-
-        for label in fig.ax_heatmap.get_xticklabels():
-            label.set_fontsize(fontsize)
-            label.set_fontfamily("DejaVu Sans")
-        for label in fig.ax_heatmap.get_yticklabels():
-            label.set_fontsize(fontsize)
-            label.set_fontfamily("DejaVu Sans")
-
-        fig.fig.subplots_adjust(bottom=0.4, left=0.1)
-        return fig
-
+        return None
+    
     heatmap_ui_initialized = reactive.Value(False)
 
     @reactive.effect
@@ -120,25 +78,26 @@ def feat_vs_anno_server(input, output, session, shared):
         ui_initialized = heatmap_ui_initialized.get()
 
         if btn and not ui_initialized:
-            # Insert feature cluster first
+            annotation_check = ui.input_checkbox("h2_anno_dendro", "Annotation Cluster", value=False)
+            ui.insert_ui(
+                ui.div({"id": "inserted-check"}, annotation_check),
+                selector="#main-hm1_check",
+                where="beforeEnd",
+            )
+
             feat_check = ui.input_checkbox("h2_feat_dendro", "Feature Cluster", value=False)
             ui.insert_ui(
                 ui.div({"id": "inserted-check1"}, feat_check),
                 selector="#main-hm2_check",
                 where="beforeEnd",
             )
-            # Insert annotation cluster below
-            annotation_check = ui.input_checkbox("h2_anno_dendro", "Annotation Cluster", value=False)
-            ui.insert_ui(
-                ui.div({"id": "inserted-check"}, annotation_check),
-                selector="#main-hm2_check",
-                where="beforeEnd",
-            )
             heatmap_ui_initialized.set(True)
+
         elif not btn and ui_initialized:
             ui.remove_ui("#inserted-check")
             ui.remove_ui("#inserted-check1")
             heatmap_ui_initialized.set(False)
+
 
     @render.download(filename="heatmap_data.csv")
     def download_df():
@@ -149,12 +108,14 @@ def feat_vs_anno_server(input, output, session, shared):
             return csv_bytes, "text/csv"
         return None
 
+
     @render.ui
     @reactive.event(input.go_hm1, ignore_none=True)
     def download_button_ui():
         if shared['df_heatmap'].get() is not None:
             return ui.download_button("download_df", "Download Data", class_="btn-warning")
         return None
+
 
     @reactive.effect
     @reactive.event(input.hm1_layer)
@@ -202,22 +163,3 @@ def feat_vs_anno_server(input, output, session, shared):
             selector="#main-max_num",
             where="beforeEnd",
         )
-
-    @reactive.effect
-    @reactive.event(input.enable_abbreviation)
-    def toggle_label_char_limit_slider():
-        if input.enable_abbreviation():
-            slider = ui.input_slider(
-                "label_char_limit",
-                "Max Characters per Label",
-                min=2,
-                max=20,
-                value=6
-            )
-            ui.insert_ui(
-                ui.div({"id": "inserted-label-char-limit"}, slider),
-                selector="#main-hm1_check",  # Or another appropriate container
-                where="beforeEnd",
-            )
-        else:
-            ui.remove_ui("#inserted-label-char-limit")

--- a/ui/feat_vs_anno_ui.py
+++ b/ui/feat_vs_anno_ui.py
@@ -38,50 +38,20 @@ def feat_vs_anno_ui():
                             value=50,
                             step=1
                         ),
-                        ui.input_slider(
-                            "hm_y_label_rotation", 
-                            "Rotate Y Axis Labels", 
-                            min=0, 
-                            max=90, 
-                            value=25
-                        ),
-
-                        ui.input_slider(
-                            "axis_label_fontsize",
-                            "Axis Label Font Size",
-                            min=3,
-                            max=24,
-                            value=10
-                        ),
-                        
-                        
-                        ui.input_checkbox(
-                            "enable_abbreviation",
-                            "Abbreviate Axis Labels",
-                            value=False
-                        ),
-                        
-                        ui.div(id="main-hm1_check"), 
-
                         ui.input_checkbox(
                             "dendogram", 
                             "Include Dendrogram", 
                             False
                         ),
-                         
+                        ui.div(id="main-hm1_check"),
                         ui.div(id="main-hm2_check"),
                         ui.div(id="main-min_num"),
                         ui.div(id="main-max_num"),
-                        # Grouped buttons with spacing
-                        
                         ui.input_action_button(
-                            "go_hm1",
-                            "Render Plot",
+                            "go_hm1", 
+                            "Render Plot", 
                             class_="btn-success"
                         ),
-                            
-
-                        
                         ui.div(
                             {"style": "padding-top: 20px;"},
                             ui.output_ui("download_button_ui")


### PR DESCRIPTION
Reverts Saran-Nag/SPAC_Shiny-Purdue-2025#1

Want to test more on it, especially the Dendrogram part that I am not familiar with. 
- Formatted the markdowns for the Denograms so that the markdowns don't interfere with the Abbreviation's markdowns

Other part of the implementation looks good:
- Introducing a Font Size Slider to adjust the fonts of both the X and Y axis
- Added an Abbreviate toggle that uses a dropdown slider to specify the length of the Abbreviation to the user
- Created a Y axis label rotator, similar to that of the already implemented X axis label rotator