### PR TITLE
fix(docker): fix 'Hash Sum Mismatch' bug on mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,16 @@ FROM python:3.9.19-slim-bookworm
 # Set working directory
 WORKDIR /app
 
+# Issue #12: Fix 'Hash Sum Mismatch' bug for mac device
+RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::http::No-Cache true;" >> /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::BrokenProxy    true;" >> /etc/apt/apt.conf.d/99custom
+
+# This is a previous method to fix this bug. It no longer works for 3.9.19-slim-bookworm
+# RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list
+
 # Install system dependencies needed for scientific packages
-RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list \
-    && apt-get update && apt-get install -y \
-# RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     git \


### PR DESCRIPTION
Fix 'Hash Sum Mismatch' bug on mac
See https://github.com/Saran-Nag/SPAC_Shiny-Purdue-2025/issues/12 for details