### PR TITLE
chore(env): update environmental files to revert python to 3.9.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 # Use official Python image as base
-# Fix: python version conflicts (Issue #15 in Purdue-2025 fork)
-# Error message when building docker:
-# Package 'datashader' requires a different Python: 3.9.19 not in '>=3.10'
-# FROM python:3.9.19-slim-bookworm
-FROM python:3.10-slim-bookworm
+FROM python:3.9.19-slim-bookworm
 
 # Set working directory
 WORKDIR /app
 
-# Fix: 'Hash Sum Mismatch' bug for mac device (Issue #12 in Purdue-2025 fork)
+# Fix 'Hash Sum Mismatch' bug for mac device
 RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
     echo "Acquire::http::No-Cache true;" >> /etc/apt/apt.conf.d/99custom && \
     echo "Acquire::BrokenProxy    true;" >> /etc/apt/apt.conf.d/99custom

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ channels:
   - leej3
   - https://fnlcr-dmap.github.io/scimap/
 dependencies:
-  - python=3.10.19  # To support datashader, need python>=3.10
+  - python=3.9.19   # To be consistent with requirement.txt
   - numpy=1.26.4
   - pandas=1.5.3
   - anndata=0.10.9
@@ -38,6 +38,10 @@ dependencies:
   - squidpy=1.2.2
   - scikit-image=0.19.3
   - scipy=1.10.1
+  # Added: packages for heatmap mode in scatterplot
+  - colorcet
+  - datashader==0.16.3
+  - dask==2024.2.1    # Needed older version of 'dask' to be compatible with panda 1.5.3
   # For macOS (MacArm64) users, uncomment the following three lines
   # - tables>=3.8.0
   # - c-blosc2
@@ -86,9 +90,6 @@ dependencies:
       - tifffile
       - shapely==2.0.7  # To be consistent with requirement.txt
       - sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-      # Added: packages for heatmap mode in scatterplot
-      - colorcet
-      - git+https://github.com/holoviz/datashader.git
       # SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
       - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ shapely==2.0.7
 sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
 # Added: packages for heatmap mode in scatterplot
 colorcet
-git+https://github.com/holoviz/datashader.git
+datashader==0.16.3
+dask==2024.2.1
 # SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
 spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac


### PR DESCRIPTION
## Description
This Pull Request downgrades Python version back to 3.9.19 as well as versions of related packages, editing `Dockerfile`, `requirement.txt` and `environment.yml`.

## Related Issue
Fixes #15

## Changes
- Downgraded Python version back to 3.9.19 in both `Dockerfile` and `environment.yml`
- Fixed 'datashader' package to 0.16.3 in both `requirement.txt` and `environment.yml`
- Added 'dask==2024.2.1' in the two files. This is due to that later version of dask needs panda>=2.0.0 which we only have 1.5.3

## Testing
Done for Mac OS. Should be universal to other systems. Local settings:
- Device: MacBook Air M1 2020 (Apple Silicon, arm64), 16 GB RAM
- Environment: Terminal in VS Code. Base conda environment activated. Docker installed. 